### PR TITLE
ListGroup enhancement: use arrow key navigation

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -14,19 +14,22 @@ function App() {
     [dataRaw, filterIncluded]
   );
 
-  const toggleListItemChecked = useCallback((id: number) => {
-    if (dataRaw) {
-      const index = dataRaw.findIndex((d) => d.id === id);
-      if (index === -1) return;
-      const datum = dataRaw[index];
-      const datumUpdated = { ...datum, checked: !datum.checked };
-      updateData([
-        ...dataRaw.slice(0, index),
-        datumUpdated,
-        ...dataRaw.slice(index + 1),
-      ]);
-    }
-  }, []);
+  const toggleListItemChecked = useCallback(
+    (id: number) => {
+      if (dataRaw) {
+        const index = dataRaw.findIndex((d) => d.id === id);
+        if (index === -1) return;
+        const datum = dataRaw[index];
+        const datumUpdated = { ...datum, checked: !datum.checked };
+        updateData([
+          ...dataRaw.slice(0, index),
+          datumUpdated,
+          ...dataRaw.slice(index + 1),
+        ]);
+      }
+    },
+    [dataRaw]
+  );
 
   function toggleMenuVisibility() {
     setMenuVisible(!menuVisible);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import styles from "./App.module.css";
 import { useData } from "../hooks/use-data";
 import { List } from "./List";
@@ -14,7 +14,7 @@ function App() {
     [dataRaw, filterIncluded]
   );
 
-  function toggleListItemChecked(id: number) {
+  const toggleListItemChecked = useCallback((id: number) => {
     if (dataRaw) {
       const index = dataRaw.findIndex((d) => d.id === id);
       if (index === -1) return;
@@ -26,7 +26,7 @@ function App() {
         ...dataRaw.slice(index + 1),
       ]);
     }
-  }
+  }, []);
 
   function toggleMenuVisibility() {
     setMenuVisible(!menuVisible);

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, memo } from "react";
 import styles from "./List.module.css";
 import { IDatum, groupData, DataGrouped } from "../lib/data";
 import { ListGroup } from "./ListGroup";
@@ -11,11 +11,12 @@ interface Props {
   preventFocus: boolean;
 }
 
-export function List({ data, handleChange, preventFocus }: Props) {
+export const List = memo(({ data, handleChange, preventFocus }: Props) => {
   const [grouped, setGrouped] = useState<DataGrouped[]>([]);
 
   useEffect(() => {
     if (data) {
+      // FIXME: causes all ListItems to re-render each time an item is (un)checked
       const grouped = groupData(data);
       setGrouped(grouped);
     }
@@ -50,4 +51,4 @@ export function List({ data, handleChange, preventFocus }: Props) {
       })}
     </div>
   );
-}
+});

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -37,11 +37,14 @@ export function List({ data, handleChange, preventFocus }: Props) {
       {grouped.map(({ aisle, items }) => {
         return (
           <ListGroup key={aisle} aisle={aisle}>
-            <ul>
-              {items.map((d) => (
-                <ListItem key={d.id} datum={d} onChange={handleChange} />
-              ))}
-            </ul>
+            {items.map((d, i) => (
+              <ListItem
+                key={d.id}
+                index={i}
+                datum={d}
+                onChange={handleChange}
+              />
+            ))}
           </ListGroup>
         );
       })}

--- a/src/components/ListGroup.tsx
+++ b/src/components/ListGroup.tsx
@@ -15,11 +15,16 @@ interface Props {
 export const ListGroup = memo(({ aisle, children }: Props) => {
   const inputsRef = useRef<HTMLInputElement[]>([]);
 
-  // useEffect(() => {
-  //   console.log(inputsRef.current);
-  // }, [inputsRef]);
+  const handleTabIndex = (index: number, value: 0 | -1) => {
+    if (inputsRef.current[index]) {
+      inputsRef.current[index].tabIndex = value;
+    }
+  };
 
-  const focusInput = (index: number) => inputsRef.current?.[index]?.focus();
+  const focusInput = (index: number) => {
+    inputsRef.current?.[index]?.focus();
+    handleTabIndex(index, 0);
+  };
 
   const getIndex = () =>
     inputsRef.current.findIndex(
@@ -29,21 +34,25 @@ export const ListGroup = memo(({ aisle, children }: Props) => {
     );
 
   const focusNext = () => {
-    const index = getIndex() + 1;
-    if (inputsRef.current[index]) {
-      focusInput(index);
+    const index = getIndex();
+    const nexIndex = index + 1;
+    if (inputsRef.current[nexIndex]) {
+      focusInput(nexIndex);
     } else {
       focusFirst();
     }
+    handleTabIndex(index, -1);
   };
 
   const focusPrev = () => {
-    const index = getIndex() - 1;
-    if (inputsRef.current[index]) {
-      focusInput(index);
+    const index = getIndex();
+    const prevIndex = index - 1;
+    if (inputsRef.current[prevIndex]) {
+      focusInput(prevIndex);
     } else {
       focusLast();
     }
+    handleTabIndex(index, -1);
   };
 
   const focusFirst = () => {

--- a/src/components/ListGroup.tsx
+++ b/src/components/ListGroup.tsx
@@ -1,7 +1,12 @@
-import React, { memo, ReactElement } from "react";
+import React, {
+  isValidElement,
+  memo,
+  PropsWithChildren,
+  ReactElement,
+} from "react";
 import styles from "./ListGroup.module.css";
 import { useRovingTabIndex } from "../hooks/use-roving-tab-index";
-import { ListItem } from "./ListItem";
+import { ListItem, Props as ListItemProps } from "./ListItem";
 
 interface Props {
   aisle: string;
@@ -19,19 +24,19 @@ export const ListGroup = memo(({ aisle, children }: Props) => {
     <details className={styles.details} open>
       <summary className={styles.categoryHeading}>{aisle}</summary>
       <ul>
-        {React.Children.map(
-          children as JSX.Element,
-          (child: ReactElement<any>, index) => {
-            if (child.type === ListItem) {
-              return React.cloneElement(child, {
+        {React.Children.map(children, (child, index) => {
+          if (isValidElement(child) && child.type === ListItem) {
+            return React.cloneElement(
+              child as ReactElement<PropsWithChildren<ListItemProps>>,
+              {
                 ref: (ref: HTMLElement) => setFocusTargetRef(ref, index),
                 tabIndex: getTabIndex(index),
                 onKeyDown: handleKeyDown,
-              });
-            }
-            return child;
+              }
+            );
           }
-        )}
+          return child;
+        })}
       </ul>
     </details>
   );

--- a/src/components/ListGroup.tsx
+++ b/src/components/ListGroup.tsx
@@ -1,4 +1,10 @@
-import React, { memo } from "react";
+import React, {
+  KeyboardEvent,
+  memo,
+  ReactElement,
+  useEffect,
+  useRef,
+} from "react";
 import styles from "./ListGroup.module.css";
 
 interface Props {
@@ -7,10 +13,46 @@ interface Props {
 }
 
 export const ListGroup = memo(({ aisle, children }: Props) => {
+  const inputsRef = useRef<HTMLInputElement[]>([]);
+
+  useEffect(() => {
+    console.log(inputsRef.current);
+  }, [inputsRef]);
+
+  const handleKeydown = (event: KeyboardEvent<HTMLUListElement>) => {
+    console.log(event.key);
+    let flag = false;
+
+    switch (event.key) {
+      case "ArrowDown":
+        // focus next
+        break;
+      case "ArrowUp":
+        // focus prev
+        break;
+      default:
+        break;
+    }
+
+    if (flag) {
+      event.preventDefault();
+    }
+  };
+
   return (
     <details className={styles.details} open>
       <summary className={styles.categoryHeading}>{aisle}</summary>
-      {children}
+      <ul onKeyDown={handleKeydown}>
+        {React.Children.map(
+          children as JSX.Element,
+          (child: ReactElement, index) => {
+            return React.cloneElement(child, {
+              ref: (ref: HTMLInputElement) =>
+                inputsRef.current ? (inputsRef.current[index] = ref) : null,
+            });
+          }
+        )}
+      </ul>
     </details>
   );
 });

--- a/src/components/ListGroup.tsx
+++ b/src/components/ListGroup.tsx
@@ -15,29 +15,73 @@ interface Props {
 export const ListGroup = memo(({ aisle, children }: Props) => {
   const inputsRef = useRef<HTMLInputElement[]>([]);
 
-  useEffect(() => {
-    console.log(inputsRef.current);
-  }, [inputsRef]);
+  // useEffect(() => {
+  //   console.log(inputsRef.current);
+  // }, [inputsRef]);
 
-  const handleKeydown = (event: KeyboardEvent<HTMLUListElement>) => {
-    console.log(event.key);
+  const focusInput = (index: number) => inputsRef.current?.[index]?.focus();
+
+  const getIndex = () =>
+    inputsRef.current.findIndex(
+      (el: HTMLInputElement) =>
+        el.dataset.id ===
+        (document.activeElement as HTMLInputElement)?.dataset?.id
+    );
+
+  const focusNext = () => {
+    const index = getIndex() + 1;
+    if (inputsRef.current[index]) {
+      focusInput(index);
+    } else {
+      focusFirst();
+    }
+  };
+
+  const focusPrev = () => {
+    const index = getIndex() - 1;
+    if (inputsRef.current[index]) {
+      focusInput(index);
+    } else {
+      focusLast();
+    }
+  };
+
+  const focusFirst = () => {
+    focusInput(0);
+  };
+
+  const focusLast = () => {
+    focusInput(inputsRef.current.length - 1);
+  };
+
+  function handleKeydown(event: KeyboardEvent<HTMLUListElement>) {
     let flag = false;
-
     switch (event.key) {
       case "ArrowDown":
-        // focus next
+      case "ArrowRight":
+        focusNext();
+        flag = true;
         break;
       case "ArrowUp":
-        // focus prev
+      case "ArrowLeft":
+        focusPrev();
+        flag = true;
+        break;
+      case "Home":
+        focusFirst();
+        flag = true;
+        break;
+      case "End":
+        focusLast();
+        flag = true;
         break;
       default:
         break;
     }
-
     if (flag) {
       event.preventDefault();
     }
-  };
+  }
 
   return (
     <details className={styles.details} open>

--- a/src/components/ListGroup.tsx
+++ b/src/components/ListGroup.tsx
@@ -1,6 +1,7 @@
 import React, { memo, ReactElement } from "react";
 import styles from "./ListGroup.module.css";
 import { useRovingTabIndex } from "../hooks/use-roving-tab-index";
+import { ListItem } from "./ListItem";
 
 interface Props {
   aisle: string;
@@ -21,11 +22,14 @@ export const ListGroup = memo(({ aisle, children }: Props) => {
         {React.Children.map(
           children as JSX.Element,
           (child: ReactElement<any>, index) => {
-            return React.cloneElement(child, {
-              ref: (ref: HTMLElement) => setFocusTargetRef(ref, index),
-              tabIndex: getTabIndex(index),
-              onKeyDown: handleKeyDown,
-            });
+            if (child.type === ListItem) {
+              return React.cloneElement(child, {
+                ref: (ref: HTMLElement) => setFocusTargetRef(ref, index),
+                tabIndex: getTabIndex(index),
+                onKeyDown: handleKeyDown,
+              });
+            }
+            return child;
           }
         )}
       </ul>

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -16,11 +16,9 @@ interface Props {
 type Ref = HTMLInputElement;
 
 export const ListItem = memo(
-  forwardRef<Ref, Props>(({ datum, onChange }, ref) => {
+  forwardRef<Ref, Props>(({ datum, onChange, index }, ref) => {
     const { item, id, checked, include } = datum;
     const htmlId = sanitize(item);
-
-    console.log("ListItem render");
 
     return (
       <li className={styles.ListItem}>
@@ -30,6 +28,7 @@ export const ListItem = memo(
           data-id={id}
           type="checkbox"
           checked={checked}
+          tabIndex={index === 0 ? 0 : -1}
           onChange={() => onChange(id)}
         />{" "}
         <label

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -1,8 +1,8 @@
-import { forwardRef, memo } from "react";
+import { forwardRef, KeyboardEvent, memo } from "react";
 import styles from "./ListItem.module.css";
 import { sanitize } from "../lib/utils";
 
-interface Props {
+export interface Props {
   datum: {
     id: number;
     item: string;
@@ -11,33 +11,38 @@ interface Props {
   };
   index: number;
   onChange: (id: number) => void;
+  tabIndex?: number;
+  onKeyDown?: (event: KeyboardEvent, index: number) => void;
 }
 
 type Ref = HTMLInputElement;
 
 export const ListItem = memo(
-  forwardRef<Ref, Props>(({ datum, onChange, index }, ref) => {
-    const { item, id, checked, include } = datum;
-    const htmlId = sanitize(item);
+  forwardRef<Ref, Props>(
+    ({ datum, onChange, onKeyDown, tabIndex, index }, ref) => {
+      const { item, id, checked, include } = datum;
+      const htmlId = sanitize(item);
 
-    return (
-      <li className={styles.ListItem}>
-        <input
-          ref={ref}
-          id={htmlId}
-          data-id={id}
-          type="checkbox"
-          checked={checked}
-          tabIndex={index === 0 ? 0 : -1}
-          onChange={() => onChange(id)}
-        />{" "}
-        <label
-          className={include ? styles.label : styles["label-not-included"]}
-          htmlFor={htmlId}
-        >
-          {item}
-        </label>
-      </li>
-    );
-  })
+      return (
+        <li className={styles.ListItem}>
+          <input
+            ref={ref}
+            id={htmlId}
+            data-id={id}
+            type="checkbox"
+            checked={checked}
+            tabIndex={tabIndex}
+            onChange={() => onChange(id)}
+            onKeyDown={(event) => onKeyDown?.(event, index)}
+          />{" "}
+          <label
+            className={include ? styles.label : styles["label-not-included"]}
+            htmlFor={htmlId}
+          >
+            {item}
+          </label>
+        </li>
+      );
+    }
+  )
 );

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -13,6 +13,7 @@ export interface Props {
   onChange: (id: number) => void;
   tabIndex?: number;
   onKeyDown?: (event: KeyboardEvent, index: number) => void;
+  ref?: (ref: HTMLElement) => void;
 }
 
 type Ref = HTMLInputElement;

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -27,6 +27,7 @@ export const ListItem = memo(
         <input
           ref={ref}
           id={htmlId}
+          data-id={id}
           type="checkbox"
           checked={checked}
           onChange={() => onChange(id)}

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { forwardRef, memo } from "react";
 import styles from "./ListItem.module.css";
 import { sanitize } from "../lib/utils";
 
@@ -9,27 +9,35 @@ interface Props {
     checked: boolean;
     include: boolean;
   };
+  index: number;
   onChange: (id: number) => void;
 }
 
-export const ListItem = memo(({ datum, onChange }: Props) => {
-  const { item, id, checked, include } = datum;
-  const htmlId = sanitize(item);
+type Ref = HTMLInputElement;
 
-  return (
-    <li className={styles.ListItem}>
-      <input
-        id={htmlId}
-        type="checkbox"
-        checked={checked}
-        onChange={() => onChange(id)}
-      />{" "}
-      <label
-        className={include ? styles.label : styles["label-not-included"]}
-        htmlFor={htmlId}
-      >
-        {item}
-      </label>
-    </li>
-  );
-});
+export const ListItem = memo(
+  forwardRef<Ref, Props>(({ datum, onChange }, ref) => {
+    const { item, id, checked, include } = datum;
+    const htmlId = sanitize(item);
+
+    console.log("ListItem render");
+
+    return (
+      <li className={styles.ListItem}>
+        <input
+          ref={ref}
+          id={htmlId}
+          type="checkbox"
+          checked={checked}
+          onChange={() => onChange(id)}
+        />{" "}
+        <label
+          className={include ? styles.label : styles["label-not-included"]}
+          htmlFor={htmlId}
+        >
+          {item}
+        </label>
+      </li>
+    );
+  })
+);

--- a/src/hooks/use-roving-tab-index.ts
+++ b/src/hooks/use-roving-tab-index.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useRef, KeyboardEvent } from "react";
+
+export const useRovingTabIndex = (
+  lastTargetIndex: number,
+  initialFocusIndex = 0
+) => {
+  const [focusTargetIndex, setFocusTargetIndex] =
+    useState<number>(initialFocusIndex);
+
+  const focusTargetRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (focusTargetRef.current) {
+      focusTargetRef.current.focus();
+    }
+  }, [focusTargetIndex, focusTargetRef]);
+
+  const updateFocusTargetIndex = (index: number) => {
+    let indexToFocus;
+    if (index > lastTargetIndex) {
+      indexToFocus = 0;
+    } else if (index < 0) {
+      indexToFocus = lastTargetIndex;
+    } else {
+      indexToFocus = index;
+    }
+    setFocusTargetIndex(indexToFocus);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent, index: number) => {
+    let flag = false;
+    switch (event.key) {
+      case "ArrowDown":
+        updateFocusTargetIndex(index + 1);
+        flag = true;
+        break;
+      case "ArrowUp":
+        updateFocusTargetIndex(index - 1);
+        flag = true;
+        break;
+      case "Home":
+        updateFocusTargetIndex(0);
+        flag = true;
+        break;
+      case "End":
+        updateFocusTargetIndex(lastTargetIndex);
+        flag = true;
+        break;
+      default:
+        break;
+    }
+    if (flag) {
+      event.preventDefault();
+    }
+  };
+
+  const setFocusTargetRef = (element: HTMLElement, index: number) => {
+    if (index === focusTargetIndex) {
+      focusTargetRef.current = element;
+    }
+  };
+
+  const getTabIndex = (index: number) => {
+    if (index === focusTargetIndex) {
+      return 0;
+    }
+    return -1;
+  };
+
+  return {
+    setFocusTargetRef,
+    getTabIndex,
+    handleKeyDown,
+  };
+};


### PR DESCRIPTION
Enable using up and down arrow keys for navigating between list group children and tabbing to only the active child in the group for improved a11y UX.